### PR TITLE
Fix SQLite B-tree iterator

### DIFF
--- a/fbe-decrypt.mjs
+++ b/fbe-decrypt.mjs
@@ -1936,6 +1936,9 @@ class SQLiteDatabase {
 				}
 			}, payload_size];
 		}
+		if (blocktype === 2 || blocktype === 5) {
+			yield *this.#iterateBTree(buffer.readUInt32BE(blockstart + 8) - 1);
+		}
 	}
 
 	async *#iterateRecords(buffer_iterator, total_size) {


### PR DESCRIPTION
Without this rows are being missed. This fixes #1.
Written by Claude but I tested that it now indeed works for me.

## Bug Found: Missing Right-Most Pointer in Interior B-Tree Pages

The bug is in `#iterateBTree`. SQLite's B-tree interior pages (types `2` and `5`) store **N** child pointers inside cells, **plus one extra "right-most pointer"** in the page header at offset `+8`. The current code iterates all cells but never follows this right-most pointer, so the entire rightmost subtree is silently skipped — causing rows to be missed for any table whose B-tree has interior pages.

### Why this happens

SQLite interior B-tree pages have this structure:

```
Header (12 bytes for interior pages):
  +0  page type (1 byte)
  +1  first freeblock offset (2 bytes)
  +3  cell count (2 bytes)
  +5  cell content area offset (2 bytes)
  +7  fragmented free bytes (1 byte)
  +8  ► RIGHT-MOST POINTER (4 bytes)  ← was never read
  +12 cell pointer array starts here
```

Each cell in an interior page holds a **left child pointer** + a key. The **right-most child** (which contains all rows with keys *greater* than the last cell's key) is only stored in the header, not in any cell. For a table with `N` interior-page children, the loop visits `N-1` of them and silently drops the last one — which can represent a large fraction of the rows.
